### PR TITLE
Enable multimodal RL under FSDP backend

### DIFF
--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -250,6 +250,9 @@ class RolloutManager:
             "sample_indices": [sample.index for sample in samples],
         }
 
+        if samples[0].prompt is not None:
+            train_data["prompt"] = [sample.prompt for sample in samples]
+
         # loss mask
         # TODO: compress the loss mask
         loss_masks = []

--- a/slime/ray/rollout_data_source.py
+++ b/slime/ray/rollout_data_source.py
@@ -34,6 +34,7 @@ class RolloutDataSource:
                 max_length=args.rollout_max_prompt_len,
                 prompt_key=args.input_key,
                 label_key=args.label_key,
+                multimodal_keys=args.multimodal_keys,
                 metadata_key=args.metadata_key,
                 tool_key=args.tool_key,
                 apply_chat_template=args.apply_chat_template,


### PR DESCRIPTION
## Summary
- propagate multimodal prompt metadata from rollout data sources into training batches
- extend the FSDP RL actor to build multimodal inputs and run vision-language updates per rollout sample

## Testing
- python -m compileall slime/slime/backends/fsdp_utils/actor.py slime/slime/ray/rollout.py slime/slime/ray/rollout_data_source.py

------
https://chatgpt.com/codex/tasks/task_e_68e099eec88483328e4c3b5317d4dc6b